### PR TITLE
Fix loading the urdf file before the robot_state_publisher requests it

### DIFF
--- a/launch/starter_kit.launch
+++ b/launch/starter_kit.launch
@@ -141,10 +141,7 @@
   </node>
 
   <!-- Robot state publisher, using the URDF model -->
-  <!--
-  <node name="robot_state_publisher" pkg="robot_state_publisher"
-        type="robot_state_publisher" >
-    <param name="robot_description" textfile="$(find swd_starter_kit_description)/urdf/swd_starter_kit.urdf" />
-  </node>
-  -->
+  <param name="robot_description" textfile="$(find swd_starter_kit_description)/urdf/swd_starter_kit.urdf" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
+
 </launch>


### PR DESCRIPTION
Hello, 
The urdf file gets loaded into the parameter server _after_ the robot_state_publisher node is running which causes the node to not find the robot_description parameter and thus failing to add the robot transformations from the urdf to the TF tree. This is a fix that simply reverses the loading order.